### PR TITLE
Fix link to proposal doc in the WICG/digital-credentials repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# This content was moved to  [https://github.com/WICG/identity-credential](https://github.com/WICG/identity-credential/blob/main/mobile-document-request-api-proposal.md)
+# This content was moved to  [https://github.com/WICG/digital-credentials](https://github.com/WICG/digital-credentials/blob/main/proposals/mobile-document-request-api-proposal.md)


### PR DESCRIPTION
The mobile-document-request-api.md proposal document is now housed in https://github.com/WICG/digital-credentials/blob/main/proposals/mobile-document-request-api-proposal.md, so let's point to the right place.